### PR TITLE
Update docs to mention React 18 *or higher*

### DIFF
--- a/docs/router/framework/react/installation.md
+++ b/docs/router/framework/react/installation.md
@@ -20,8 +20,8 @@ TanStack Router is currently only compatible with React and ReactDOM. If you wou
 
 ### Requirements
 
-- React v18.x.x
-- ReactDOM v18.x.x
+- React 18 or above
+- ReactDOM 18 or above
   - Note that `ReactDOM.createRoot` is required.
   - The legacy `.render()` function is not supported.
 - TypeScript >= v5.3.x (TypeScript is optional, but recommended)


### PR DESCRIPTION
I was a bit concerned when first reading the installation guides that React 19 might not be supported.  This wording hopefully makes that a bit clearer.